### PR TITLE
 [FEAT] : input에 입력시 0.5초 디바운스 기능을 추가합니다

### DIFF
--- a/src/components/InputTodo.tsx
+++ b/src/components/InputTodo.tsx
@@ -3,7 +3,8 @@ import { useCallback, useEffect, useState } from "react";
 
 import { createTodo } from "../api/todo";
 import useFocus from "../hooks/useFocus";
-import RecommendTodo from "./Dropdown";
+import Dropdown from "./Dropdown";
+import useDebounce from "../hooks/useDebounce";
 
 type InputTodoProps = {
   setTodos: React.Dispatch<React.SetStateAction<TodoItem[]>>;
@@ -13,6 +14,8 @@ const InputTodo = ({ setTodos }: InputTodoProps) => {
   const [inputText, setInputText] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const { ref, setFocus } = useFocus();
+
+  const debouncedText = useDebounce(inputText, 500);
 
   useEffect(() => {
     setFocus();
@@ -69,7 +72,7 @@ const InputTodo = ({ setTodos }: InputTodoProps) => {
           <FaSpinner className="spinner" />
         )}
       </form>
-      {inputText && <RecommendTodo text={inputText} />}
+      {debouncedText && <Dropdown text={debouncedText} />}
     </>
   );
 };

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,16 @@
+import { useState, useEffect } from "react";
+export default function useDebounce<T>(value: T, delay: number) {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timerId = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(timerId);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
## 🐣 개요
- 입력시 마다 api를 호출하지 않도록 디바운스 기능을 추가합니다.
## 🐣 작업사항
- 재사용이 가능하도록 useDebounce 훅을 만들었습니다.
- input에 텍스트를 입력시 0.5초 안에 입력한 텍스트를 모으고, 모아진 텍스트를 props로 Dropdown에 넘겨줍니다.
